### PR TITLE
Add config file support to the agent

### DIFF
--- a/conf/kool-agent-dev.conf
+++ b/conf/kool-agent-dev.conf
@@ -1,0 +1,4 @@
+{
+    "ServerURL": "http://localhost:3000",
+    "AgentId": 1
+}

--- a/conf/kool-agent.conf
+++ b/conf/kool-agent.conf
@@ -1,0 +1,4 @@
+{
+    "ServerURL": "http://api.koolmonkey.xyz",
+    "AgentId": 1
+}

--- a/src/kool-agent/job-runner.go
+++ b/src/kool-agent/job-runner.go
@@ -41,11 +41,11 @@ func uploadResults(job *Job, testResults string, duration time.Duration) error {
 	resultData["url"] = job.TargetURL
 	resultData["testResults"] = testResults
 	resultData["response_time"] = duration
-	resultData["agentId"] = AgentId
+	resultData["agentId"] = Conf.AgentId
 
 	b, _ := json.Marshal(resultData)
 	reader := strings.NewReader(string(b))
-	request, err := http.NewRequest("POST", fmt.Sprintf("%s/result", ServerURL), reader)
+	request, err := http.NewRequest("POST", fmt.Sprintf("%s/result", Conf.ServerURL), reader)
 	if err != nil {
 		return err
 	}

--- a/src/kool-agent/jobs-poller.go
+++ b/src/kool-agent/jobs-poller.go
@@ -26,7 +26,7 @@ func jobs_poller(jobsChan chan []SingleTest) error {
 	serverMethod := "alive"
 
 	aliveData := make(map[string]interface{})
-	aliveData["agentId"] = AgentId
+	aliveData["agentId"] = Conf.AgentId
 
 	sleep_interval := time.Duration(polling_interval) * time.Second
 
@@ -38,7 +38,7 @@ func jobs_poller(jobsChan chan []SingleTest) error {
 		reader := strings.NewReader(string(b))
 
 		request, err := http.NewRequest("POST",
-			fmt.Sprintf("%s/%s", ServerURL, serverMethod),
+			fmt.Sprintf("%s/%s", Conf.ServerURL, serverMethod),
 			reader)
 
 		if err != nil {

--- a/src/kool-agent/kool-agent.go
+++ b/src/kool-agent/kool-agent.go
@@ -1,17 +1,38 @@
 package main
 
 import (
+	"encoding/json"
+	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 )
 
-var AgentId int64 = -1
-var ServerURL string = "http://api.koolmonkey.xyz"
+type AgentConf struct {
+	ServerURL string
+	AgentId   int64
+}
+
+var Conf AgentConf = AgentConf{}
 
 func main() {
 	fmt.Println("Starting agent!")
+	topDir, err := filepath.Abs(filepath.Dir(os.Args[0]) + "/../")
 
-	// XXX This needs to be replaced with the value got from the registration
-	AgentId = 1
+	cmd_cfg := flag.String("conf", topDir+"/conf/kool-agent.conf", "Config file")
+	flag.Parse()
+	file, err := os.Open(*cmd_cfg)
+	if err != nil {
+		fmt.Printf("Config - File Error: %s\n", err)
+		os.Exit(1)
+	}
+
+	decoder := json.NewDecoder(file)
+
+	if err := decoder.Decode(&Conf); err != nil {
+		fmt.Printf("Config - Decoding Error: %s\n", err)
+		os.Exit(1)
+	}
 
 	// Set up Channels
 	jobsChannel := make(chan []SingleTest)


### PR DESCRIPTION
Add support for parsing a config file at startup, and provide
a couple of ready-made config files for testing / running live.
