### PR TITLE
Fix the binary installation when an installation was already present.

### DIFF
--- a/Config.mk
+++ b/Config.mk
@@ -16,6 +16,7 @@ USR_BIN=/usr/bin
 USR_SBIN=/usr/sbin
 RM=rm -fr
 MKDIR=mkdir -p
+CP=cp -fr
 
 DATABASE=monkey
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install: $(BIN)
 	@for i in $(DIRS) ; do $(MAKE) -C $$i install ; done
 	@mkdir -p $(BIN_DIR)
 	@for i in $(BIN); do \
-		cp bin/$$i $(BIN_DIR); \
+		$(CP) bin/$$i $(BIN_DIR); \
 	done
 	@echo "\\033[1;35m+++ System installed\\033[39;0m"
 

--- a/conf/Makefile
+++ b/conf/Makefile
@@ -11,7 +11,7 @@ install:
 	@mkdir -p $(CONF_DIR)
 	@for i in $(DIRS) ; do $(MAKE) -C $$i install ; done
 	@for i in $(SRCS); do \
-		cp $$i $(CONF_DIR) ; \
+		$(CP) $$i $(CONF_DIR) ; \
 		perl -i -pne 's/%(\w+?)%/$$ENV{$$1}/ge' $(CONF_DIR)/$$i ; \
 	done
 	@echo "\\033[1;35m+++ Conf installed\\033[39;0m"

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -9,7 +9,7 @@ install:
 	@mkdir -p $(SCRIPTS_DIR)
 	@for i in $(DIRS) ; do $(MAKE) -C $$i install ; done
 	@for i in $(SRCS); do \
-		cp $$i $(SCRIPTS_DIR) ; \
+		$(CP) $$i $(SCRIPTS_DIR) ; \
 		perl -i -pne 's/%(\w+?)%/$$ENV{$$1}/ge' $(SCRIPTS_DIR)/$$i ; \
 	done
 	@echo "\\033[1;35m+++ Conf installed\\033[39;0m"

--- a/scripts/db/Makefile
+++ b/scripts/db/Makefile
@@ -12,7 +12,7 @@ install:
 	@mkdir -p $(SCRIPTS_DIR)
 	@for i in $(DIRS) ; do $(MAKE) -C $$i install ; done
 	@for i in $(SRCS); do \
-		cp $$i $(SCRIPTS_DIR) ; \
+		$(CP) $$i $(SCRIPTS_DIR) ; \
 		perl -i -pne 's/%(\w+?)%/$$ENV{$$1}/ge' $(SCRIPTS_DIR)/$$i ; \
 	done
 	@echo "\\033[1;35m+++ Conf installed\\033[39;0m"


### PR DESCRIPTION
When there's a previous installation of kool_agent and kool_server the
install target fails because cp fails, so we force the copy of the
binaries.
