### PR TITLE
Do not run the deploy stage for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,9 @@ addons:
     packages:
     - rpm
 
-before_install:
-- openssl aes-256-cbc -K $encrypted_a939b7674977_key -iv $encrypted_a939b7674977_iv -in deploy/deploy_key.enc -out deploy/deploy_key -d
-
 install: true
 
 script:
 - make kool-server
 - make clean
 - make rpm-build
-
-before_deploy:
-- eval "$(ssh-agent -s)"
-- chmod 600 deploy/deploy_key
-- ssh-add deploy/deploy_key
-
-deploy:
-  skip_cleanup: true
-  provider: script
-  script: deploy/deploy.sh
-  on:
-    branch: master


### PR DESCRIPTION
Since the deploy pipeline was built for the purpose of Gophergala,
disable it as well as the certificate handling.
