### PR TITLE
Add initial support for Agent Docker Image

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,0 +1,16 @@
+FROM centos:centos7
+MAINTAINER Sergio Visinoni <piffio@piffio.org>
+
+RUN yum install -y bzip2 fontconfig
+
+ENV PHANTOMJS_VER 2.1.1-linux-x86_64
+
+RUN curl -sSL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOMJS_VER.tar.bz2 | tar jxC /
+RUN ln -s /phantomjs-$PHANTOMJS_VER/bin/phantomjs /usr/bin/phantomjs
+RUN mkdir -p /scripts && ln -s /phantomjs-$PHANTOMJS_VER/examples /scripts/phantomjs
+COPY bin/kool-agent /
+COPY conf/kool-agent*.conf /
+
+ENTRYPOINT [ "/kool-agent", "-conf"]
+# Default will be production
+CMD [ "/kool-agent.conf" ]

--- a/Makefile
+++ b/Makefile
@@ -78,3 +78,6 @@ info:
 rpm-build:
 	rpmbuild --quiet --nobuild --rcfile ${RPM_DIR}/rpmrc --macros=/usr/lib/rpm/macros:${RPM_DIR}/rpmmacros ${RPM_DIR}/kool-server.spec 2>&1 | grep error; if [ $$? == 0 ] ; then exit 1; fi
 	rpmbuild -bb --rcfile ${RPM_DIR}/rpmrc --target x86_64-linux --macros=/usr/lib/rpm/macros:${RPM_DIR}/rpmmacros --buildroot=${TOPDIR}/dest/kool-server ${RPM_DIR}/kool-server.spec
+
+docker-agent: install
+	docker build -t kool-agent -f Dockerfile.agent .


### PR DESCRIPTION
Add support for building a Docker Image that can be used
to run the agent in test / production environment(s)

Currently it's based out of CentOS 7, but this can be
changed later for a better/smaller/slimmer base image
in the future.

This fixes issues #5
